### PR TITLE
Avoid creating too much thread pools

### DIFF
--- a/mars/storage/core.py
+++ b/mars/storage/core.py
@@ -17,7 +17,7 @@
 import asyncio
 import os
 from abc import ABC, abstractmethod
-from concurrent.futures import Executor, ThreadPoolExecutor
+from concurrent.futures import Executor
 from typing import Any, Optional, Union
 
 from ..lib.aio import AioFileObject
@@ -32,8 +32,6 @@ class StorageFileObject(AioFileObject):
         executor: Executor = None,
     ):
         self._object_id = object_id
-        if executor is None:
-            executor = ThreadPoolExecutor()
         super().__init__(file, loop=loop, executor=executor)
 
     @property


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
`AioFileObject` will use current loop's thread pool, we don't need to create and pass a new thread pool when initialize `StorageFileObject`.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
