### PR TITLE
Generate map-reduce info for shuffle operands

### DIFF
--- a/mars/core/operand/shuffle.py
+++ b/mars/core/operand/shuffle.py
@@ -50,6 +50,12 @@ class MapReduceOperand(Operand):
     reducer_ordinal = Int32Field("reducer_ordinal")
     reducer_phase = StringField("reducer_phase", default=None)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.stage == OperandStage.reduce:
+            # for reducer, we assign worker at first
+            self.scheduling_hint.reassign_worker = True
+
     def _new_chunks(self, inputs, kws=None, **kw):
         if getattr(self, "reducer_index", None) is None:
             index = None

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -17,7 +17,7 @@ import logging
 import sys
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Type, Tuple
+from typing import Any, Dict, List, Optional, Set, Type
 
 from .... import oscar as mo
 from ....core import ChunkGraph, OperandType, enter_mode, ExecutionError
@@ -27,7 +27,6 @@ from ....core.operand import (
     FetchShuffle,
     execute,
 )
-from ....lib.aio import alru_cache
 from ....metrics import Metrics
 from ....optimization.physical import optimize
 from ....typing import BandType, ChunkType

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -439,23 +439,6 @@ class SubtaskProcessor:
         # set result data size
         self.result.data_size = result_data_size
 
-    @classmethod
-    @alru_cache(cache_exceptions=False)
-    async def _gen_reducer_index_to_bands(
-        cls, session_id: str, supervisor_address: str, task_id: str, map_reduce_id: int
-    ) -> Dict[Tuple[int], BandType]:
-        task_api = await TaskAPI.create(session_id, supervisor_address)
-        map_reduce_info = await task_api.get_map_reduce_info(task_id, map_reduce_id)
-        assert len(map_reduce_info.reducer_indexes) == len(
-            map_reduce_info.reducer_bands
-        )
-        return {
-            reducer_index: band
-            for reducer_index, band in zip(
-                map_reduce_info.reducer_indexes, map_reduce_info.reducer_bands
-            )
-        }
-
     async def done(self):
         if self.result.status == SubtaskStatus.running:
             self.result.status = SubtaskStatus.succeeded

--- a/mars/services/subtask/worker/processor.py
+++ b/mars/services/subtask/worker/processor.py
@@ -17,7 +17,7 @@ import logging
 import sys
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Type
+from typing import Any, Dict, List, Optional, Set, Type, Tuple
 
 from .... import oscar as mo
 from ....core import ChunkGraph, OperandType, enter_mode, ExecutionError
@@ -27,6 +27,7 @@ from ....core.operand import (
     FetchShuffle,
     execute,
 )
+from ....lib.aio import alru_cache
 from ....metrics import Metrics
 from ....optimization.physical import optimize
 from ....typing import BandType, ChunkType
@@ -437,6 +438,23 @@ class SubtaskProcessor:
                 raise
         # set result data size
         self.result.data_size = result_data_size
+
+    @classmethod
+    @alru_cache(cache_exceptions=False)
+    async def _gen_reducer_index_to_bands(
+        cls, session_id: str, supervisor_address: str, task_id: str, map_reduce_id: int
+    ) -> Dict[Tuple[int], BandType]:
+        task_api = await TaskAPI.create(session_id, supervisor_address)
+        map_reduce_info = await task_api.get_map_reduce_info(task_id, map_reduce_id)
+        assert len(map_reduce_info.reducer_indexes) == len(
+            map_reduce_info.reducer_bands
+        )
+        return {
+            reducer_index: band
+            for reducer_index, band in zip(
+                map_reduce_info.reducer_indexes, map_reduce_info.reducer_bands
+            )
+        }
 
     async def done(self):
         if self.result.status == SubtaskStatus.running:

--- a/mars/services/subtask/worker/tests/test_subtask.py
+++ b/mars/services/subtask/worker/tests/test_subtask.py
@@ -180,7 +180,7 @@ async def test_shuffle_subtask(actor_pool):
     subtask_runner: SubtaskRunnerRef = await mo.actor_ref(
         SubtaskRunnerActor.gen_uid("numa-0", 0), address=pool.external_address
     )
-    await subtask_runner.run_subtask(subtask, wait_post_run=True)
+    await subtask_runner.run_subtask(subtask)
     result = await subtask_runner.get_subtask_result()
     assert result.status == SubtaskStatus.succeeded
 

--- a/mars/services/task/__init__.py
+++ b/mars/services/task/__init__.py
@@ -14,5 +14,5 @@
 
 from .api import AbstractTaskAPI, TaskAPI, WebTaskAPI
 from .config import task_options
-from .core import Task, TaskStatus, TaskResult, new_task_id
+from .core import Task, TaskStatus, TaskResult, new_task_id, MapReduceInfo
 from .errors import TaskNotExist

--- a/mars/services/task/analyzer/analyzer.py
+++ b/mars/services/task/analyzer/analyzer.py
@@ -25,14 +25,15 @@ from ....core.operand import (
     LogicKeyGenerator,
     MapReduceOperand,
     OperandStage,
-    ShuffleFetchType,
     ShuffleProxy,
+    ShuffleFetchType,
 )
+from ....lib.ordered_set import OrderedSet
 from ....resource import Resource
 from ....typing import BandType, OperandType
 from ....utils import build_fetch, build_fetch_shuffle, tokenize
 from ...subtask import SubtaskGraph, Subtask
-from ..core import Task, new_task_id
+from ..core import Task, new_task_id, MapReduceInfo
 from .assigner import AbstractGraphAssigner, GraphAssigner
 from .fusion import Coloring
 
@@ -59,6 +60,8 @@ class GraphAnalyzer:
     chunk graph and generated subtask graph.
     """
 
+    _map_reduce_id = itertools.count()
+
     def __init__(
         self,
         chunk_graph: ChunkGraph,
@@ -68,6 +71,7 @@ class GraphAnalyzer:
         chunk_to_subtasks: Dict[ChunkType, Subtask],
         graph_assigner_cls: Type[AbstractGraphAssigner] = None,
         stage_id: str = None,
+        map_reduce_id_to_infos: Dict[int, MapReduceInfo] = None,
         shuffle_fetch_type: ShuffleFetchType = ShuffleFetchType.FETCH_BY_KEY,
     ):
         self._chunk_graph = chunk_graph
@@ -83,11 +87,16 @@ class GraphAnalyzer:
         self._fuse_enabled = task.fuse_enabled
         self._extra_config = task.extra_config
         self._chunk_to_subtasks = chunk_to_subtasks
+        self._map_reduce_id_to_infos = map_reduce_id_to_infos
         if graph_assigner_cls is None:
             graph_assigner_cls = GraphAssigner
         self._graph_assigner_cls = graph_assigner_cls
         self._chunk_to_copied = dict()
         self._logic_key_generator = LogicKeyGenerator()
+
+    @classmethod
+    def next_map_reduce_id(cls) -> int:
+        return next(cls._map_reduce_id)
 
     @classmethod
     def _iter_start_ops(cls, chunk_graph: ChunkGraph):
@@ -333,6 +342,38 @@ class GraphAnalyzer:
             *[self._logic_key_generator.get_logic_key(chunk.op) for chunk in chunks]
         )
 
+    def _gen_map_reduce_info(
+        self, chunk: ChunkType, assign_results: Dict[ChunkType, BandType]
+    ):
+        reducer_ops = OrderedSet(
+            [
+                c.op
+                for c in self._chunk_graph.successors(chunk)
+                if c.op.stage == OperandStage.reduce
+            ]
+        )
+        map_chunks = [
+            c
+            for c in self._chunk_graph.predecessors(chunk)
+            if c.op.stage == OperandStage.map
+        ]
+        map_reduce_id = self.next_map_reduce_id()
+        for map_chunk in map_chunks:
+            # record analyzer map reduce id for mapper op
+            # copied chunk exists because map chunk must have
+            # been processed before shuffle proxy
+            copied_map_chunk_op = self._chunk_to_copied[map_chunk].op
+            if not hasattr(copied_map_chunk_op, "extra_params"):
+                copied_map_chunk_op.extra_params = dict()
+            copied_map_chunk_op.extra_params["analyzer_map_reduce_id"] = map_reduce_id
+        reducer_bands = [assign_results[r.outputs[0]] for r in reducer_ops]
+        map_reduce_info = MapReduceInfo(
+            map_reduce_id=map_reduce_id,
+            reducer_indexes=[reducer_op.reducer_index for reducer_op in reducer_ops],
+            reducer_bands=reducer_bands,
+        )
+        self._map_reduce_id_to_infos[map_reduce_id] = map_reduce_info
+
     @enter_mode(build=True)
     def gen_subtask_graph(
         self, op_to_bands: Dict[str, BandType] = None
@@ -492,6 +533,10 @@ class GraphAnalyzer:
 
             for c in same_color_chunks:
                 chunk_to_subtask[c] = subtask
+            if self._map_reduce_id_to_infos is not None and isinstance(
+                chunk.op, ShuffleProxy
+            ):
+                self._gen_map_reduce_info(chunk, chunk_to_bands)
             visited.update(same_color_chunks)
 
         for subtasks in logic_key_to_subtasks.values():

--- a/mars/services/task/api/oscar.py
+++ b/mars/services/task/api/oscar.py
@@ -18,7 +18,7 @@ from .... import oscar as mo
 from ....core import Tileable
 from ....lib.aio import alru_cache
 from ...subtask import SubtaskResult
-from ..core import TileableGraph, TaskResult
+from ..core import TileableGraph, TaskResult, MapReduceInfo
 from ..supervisor.manager import TaskManagerActor
 from .core import AbstractTaskAPI
 
@@ -106,3 +106,8 @@ class TaskAPI(AbstractTaskAPI):
 
     async def remove_tileables(self, tileable_keys: List[str]):
         return await self._task_manager_ref.remove_tileables(tileable_keys)
+
+    async def get_map_reduce_info(
+        self, task_id: str, map_reduce_id: int
+    ) -> MapReduceInfo:
+        return await self._task_manager_ref.get_map_reduce_info(task_id, map_reduce_id)

--- a/mars/services/task/core.py
+++ b/mars/services/task/core.py
@@ -15,17 +15,20 @@
 import random
 from enum import Enum
 from string import ascii_letters, digits
-from typing import Any, Optional, Dict
+from typing import Any, Optional, Dict, List, Tuple
 
 from ...core import TileableGraph
+from ...typing import BandType
 from ...serialization.serializables import (
     Serializable,
+    FieldTypes,
     StringField,
     ReferenceField,
     Int32Field,
     BoolField,
     AnyField,
     DictField,
+    ListField,
     Float64Field,
 )
 
@@ -104,3 +107,17 @@ class TaskResult(Serializable):
 
 def new_task_id():
     return "".join(random.choice(ascii_letters + digits) for _ in range(24))
+
+
+class MapReduceInfo(Serializable):
+    # record map reduce info during analyzing
+    # record reducer indexes, and assigned bands
+    map_reduce_id: int = Int32Field("map_reduce_id")
+    reducer_indexes: List[Tuple[int]] = ListField(
+        "reducer_indexes", FieldTypes.tuple(FieldTypes.int64), default_factory=list
+    )
+    reducer_bands: List[BandType] = ListField(
+        "reducer_bands",
+        FieldTypes.tuple(FieldTypes.string, FieldTypes.string),
+        default_factory=list,
+    )

--- a/mars/services/task/supervisor/manager.py
+++ b/mars/services/task/supervisor/manager.py
@@ -29,7 +29,7 @@ from ....oscar.errors import ServerClosed, ActorNotExist
 from ....utils import aiotask_wrapper, _is_ci
 from ...subtask import SubtaskResult, SubtaskGraph
 from ..config import task_options
-from ..core import Task, new_task_id, TaskStatus
+from ..core import Task, new_task_id, TaskStatus, MapReduceInfo
 from ..errors import TaskNotExist
 from .preprocessor import TaskPreprocessor
 from .processor import TaskProcessor
@@ -373,3 +373,13 @@ class TaskManagerActor(mo.Actor):
                     if not is_done
                 ]
                 self._result_tileable_key_to_info[key] = not_done_info
+
+    async def get_map_reduce_info(
+        self, task_id: str, map_reduce_id: int
+    ) -> MapReduceInfo:
+        try:
+            processor_ref = self._task_id_to_processor_ref[task_id]
+        except KeyError:  # pragma: no cover
+            raise TaskNotExist(f"Task {task_id} does not exist")
+
+        return await processor_ref.get_map_reduce_info(map_reduce_id)

--- a/mars/services/task/supervisor/preprocessor.py
+++ b/mars/services/task/supervisor/preprocessor.py
@@ -26,7 +26,7 @@ from ....resource import Resource
 from ....typing import BandType, TileableType, ChunkType
 from ...subtask import Subtask, SubtaskGraph
 from ..analyzer import GraphAnalyzer
-from ..core import Task
+from ..core import Task, MapReduceInfo
 
 logger = logging.getLogger(__name__)
 
@@ -112,9 +112,11 @@ class TaskPreprocessor:
         "chunk_optimization_records_list",
         "_cancelled",
         "_done",
+        "map_reduce_id_to_infos",
     )
 
     tile_context: TileContext
+    map_reduce_id_to_infos: Dict[int, MapReduceInfo]
 
     def __init__(
         self,
@@ -129,6 +131,7 @@ class TaskPreprocessor:
         self.tile_context = tiled_context
         self.tileable_optimization_records = None
         self.chunk_optimization_records_list = []
+        self.map_reduce_id_to_infos = dict()
 
         self._cancelled = asyncio.Event()
         self._done = asyncio.Event()
@@ -226,6 +229,7 @@ class TaskPreprocessor:
             chunk_to_subtasks,
             stage_id=stage_id,
             shuffle_fetch_type=shuffle_fetch_type,
+            map_reduce_id_to_infos=self.map_reduce_id_to_infos,
         )
         graph = analyzer.gen_subtask_graph(op_to_bands)
         logger.debug(
@@ -252,6 +256,9 @@ class TaskPreprocessor:
     def get_tiled(self, tileable: TileableType):
         tileable = tileable.data if hasattr(tileable, "data") else tileable
         return self.tile_context[tileable]
+
+    def get_map_reduce_info(self, map_reduce_id: int) -> MapReduceInfo:
+        return self.map_reduce_id_to_infos[map_reduce_id]
 
     def __await__(self):
         return self._done.wait().__await__()

--- a/mars/services/task/supervisor/processor.py
+++ b/mars/services/task/supervisor/processor.py
@@ -30,7 +30,7 @@ from ....oscar.profiling import (
 from ....typing import TileableType, ChunkType
 from ....utils import Timer
 from ...subtask import SubtaskResult, Subtask
-from ..core import Task, TaskResult, TaskStatus, new_task_id
+from ..core import Task, TaskResult, TaskStatus, new_task_id, MapReduceInfo
 from ..execution.api import TaskExecutor, ExecutionChunkResult
 from .preprocessor import TaskPreprocessor
 
@@ -414,6 +414,9 @@ class TaskProcessor:
             cost_time_secs,
             {"session_id": self._task.session_id, "task_id": self._task.task_id},
         )
+
+    def get_map_reduce_info(self, map_reduce_id: int) -> MapReduceInfo:
+        return self._preprocessor.get_map_reduce_info(map_reduce_id)
 
     def dump_subtask_graph(self):
         from .graph_visualizer import GraphVisualizer

--- a/mars/services/task/supervisor/task.py
+++ b/mars/services/task/supervisor/task.py
@@ -25,7 +25,7 @@ from ....core.operand import Fetch
 from ....typing import TileableType
 from ....utils import build_fetch
 from ...subtask import SubtaskResult, SubtaskStatus, SubtaskGraph
-from ..core import Task, TaskStatus
+from ..core import Task, TaskStatus, MapReduceInfo
 from ..execution.api import TaskExecutor
 from .preprocessor import TaskPreprocessor
 from .processor import TaskProcessor
@@ -416,6 +416,10 @@ class TaskProcessorActor(mo.Actor, _TaskInfoProcessorMixin):
         )
         if self._cur_processor is not None:
             yield self._cur_processor.set_subtask_result(subtask_result)
+
+    async def get_map_reduce_info(self, map_reduce_id: int) -> MapReduceInfo:
+        for processor in self._task_id_to_processor.values():
+            return processor.get_map_reduce_info(map_reduce_id)
 
     def is_done(self) -> bool:
         for processor in self._task_id_to_processor.values():

--- a/mars/services/task/supervisor/tests/test_task_manager.py
+++ b/mars/services/task/supervisor/tests/test_task_manager.py
@@ -497,6 +497,25 @@ async def test_shuffle(actor_pool):
     )
     np.testing.assert_array_equal(result, expect)
 
+    # test generating map reduce info
+    subtask_graphs = (await manager.get_subtask_graphs(task_id))[0]
+    map_reduce_ids = []
+    for subtask in subtask_graphs:
+        for chunk in subtask.chunk_graph.result_chunks:
+            map_reduce_id = getattr(chunk.op, "extra_params", dict()).get(
+                "analyzer_map_reduce_id"
+            )
+            if map_reduce_id is not None:
+                map_reduce_ids.append(map_reduce_id)
+    assert len(map_reduce_ids) > 0
+    map_reduce_info = await manager.get_map_reduce_info(task_id, map_reduce_ids[0])
+    assert (
+        len(set(map_reduce_info.reducer_indexes))
+        == len(map_reduce_info.reducer_indexes)
+        == len(map_reduce_info.reducer_bands)
+        > 0
+    )
+
     # test ref counts
     assert (await lifecycle_api.get_tileable_ref_counts([c.key]))[0] == 1
     assert (

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ dev =
     pytest-cov>=2.5.0
     pytest-timeout>=1.2.0
     pytest-forked>=1.0
-    pytest-asyncio>=0.14.0
+    pytest-asyncio>=0.17.0
     mock>=4.0.0; python_version<"3.8"
     flake8>=3.8.0
     black


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- Generate map-reduce info.
- Reassign reducers.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
