### PR TITLE
enh: Support specifying output types for remote functions

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -88,7 +88,7 @@ jobs:
               ./ci/install-hadoop.sh
               echo "import coverage; coverage.process_startup()" > \
                 $(python -c "import site; print(site.getsitepackages()[-1])")/coverage.pth
-              conda install -n test --quiet --yes -c conda-forge python=$PYTHON skein conda-pack
+              conda install -n test --quiet --yes -c conda-forge python=$PYTHON skein libffi conda-pack
             fi
             if [ -n "$WITH_VINEYARD" ]; then
               pip install vineyard -i https://pypi.org/simple
@@ -185,7 +185,7 @@ jobs:
             export MARS_CI_BACKEND=ray
             export RAY_idle_worker_killing_time_threshold_ms=60000
             pytest $PYTEST_CONFIG --durations=0 --timeout=500 mars/dataframe -v -s -m "not skip_ray_dag" --ignore=mars/dataframe/contrib/raydataset
-            pytest $PYTEST_CONFIG --durations=0 --timeout=500 mars/dataframe/contrib/raydataset -v -s -m "not skip_ray_dag" 
+            pytest $PYTEST_CONFIG --durations=0 --timeout=500 mars/dataframe/contrib/raydataset -v -s -m "not skip_ray_dag"
             pytest $PYTEST_CONFIG --durations=0 --timeout=500 mars/tensor -v -s -m "not skip_ray_dag"
             pytest $PYTEST_CONFIG --durations=0 --timeout=500 mars/learn --ignore mars/learn/contrib --ignore mars/learn/utils/tests/test_collect_ports.py -v -s -m "not skip_ray_dag"
             pytest $PYTEST_CONFIG --durations=0 --timeout=200 -v -s -m ray_dag

--- a/mars/core/entity/utils.py
+++ b/mars/core/entity/utils.py
@@ -19,7 +19,7 @@ from ...utils import has_unknown_shape, calc_nsplits
 
 
 def refresh_tileable_shape(tileable):
-    if has_unknown_shape(tileable):
+    if tileable.shape is None or has_unknown_shape(tileable):
         # update shape
         nsplits = calc_nsplits({c.index: c.shape for c in tileable.chunks})
         shape = tuple(sum(ns) for ns in nsplits)

--- a/mars/dataframe/core.py
+++ b/mars/dataframe/core.py
@@ -425,7 +425,8 @@ def refresh_index_value(tileable: ENTITY_TYPE):
             index_to_index_values[chunk.index] = chunk.index_value
     index_value = merge_index_value(index_to_index_values, store_data=False)
     # keep key as original index_value's
-    index_value._index_value._key = tileable.index_value.key
+    if tileable.index_value is not None:
+        index_value._index_value._key = tileable.index_value.key
     tileable._index_value = index_value
 
 
@@ -1374,7 +1375,7 @@ class BaseSeriesData(HasShapeTileableData, _ToPandasMixin):
 
     @property
     def dtype(self):
-        return getattr(self, "_dtype", None) or self.op.dtype
+        return getattr(self, "_dtype", None) or getattr(self.op, "dtype", None)
 
     @property
     def name(self):

--- a/mars/tensor/core.py
+++ b/mars/tensor/core.py
@@ -148,7 +148,7 @@ class TensorChunkData(ChunkData):
 
     @property
     def dtype(self):
-        return getattr(self, "_dtype", None) or self.op.dtype
+        return getattr(self, "_dtype", None) or getattr(self.op, "dtype", None)
 
     @property
     def order(self):
@@ -287,7 +287,7 @@ class TensorData(HasShapeTileableData, _ExecuteAndFetchMixin):
 
     @property
     def dtype(self):
-        return getattr(self, "_dtype", None) or self.op.dtype
+        return getattr(self, "_dtype", None) or getattr(self.op, "dtype", None)
 
     @property
     def order(self):

--- a/mars/tests/core.py
+++ b/mars/tests/core.py
@@ -261,7 +261,7 @@ class ObjectCheckMixin:
         return value
 
     def assert_shape_consistent(self, expected_shape, real_shape):
-        if not self._check_options["check_shape"]:
+        if not self._check_options["check_shape"] or not expected_shape:
             return
 
         if len(expected_shape) != len(real_shape):
@@ -336,7 +336,7 @@ class ObjectCheckMixin:
 
     @classmethod
     def assert_index_value_consistent(cls, expected_index_value, real_index):
-        if expected_index_value.has_value():
+        if expected_index_value is not None and expected_index_value.has_value():
             expected_index = expected_index_value.to_pandas()
             try:
                 pd.testing.assert_index_equal(
@@ -357,6 +357,8 @@ class ObjectCheckMixin:
             real = real[0]
         if not isinstance(real, dataframe_types):
             raise AssertionError(f"Type of real value ({type(real)}) not DataFrame")
+        if expected.shape is None:
+            return
         self.assert_shape_consistent(expected.shape, real.shape)
         if not np.isnan(expected.shape[1]) and expected.dtypes is not None:
             if self._check_options["check_dtypes"]:
@@ -390,11 +392,12 @@ class ObjectCheckMixin:
             raise AssertionError(f"Type of real value ({type(real)}) not Series")
         self.assert_shape_consistent(expected.shape, real.shape)
 
-        if self._check_options["check_series_name"] and expected.name != real.name:
-            raise AssertionError(
-                f"series name in metadata {expected.name} "
-                f"is not equal to real name {real.name}"
-            )
+        if self._check_options["check_series_name"]:
+            if expected.name is not None and expected.name != real.name:
+                raise AssertionError(
+                    f"series name in metadata {expected.name} "
+                    f"is not equal to real name {real.name}"
+                )
 
         self.assert_dtype_consistent(expected.dtype, real.dtype)
         if self._check_options["check_index_value"]:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
For now, remote functions always return an `ObjectData` even the function's return value is determined. In this PR, we can specify output types to return a `DataFrameData` or `SeriesData` that contains only one chunk, it will make remote function more flexible.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
