### PR TITLE
enh: Add `skip_infer` paramter for all use defined functions

### DIFF
--- a/mars/dataframe/base/apply.py
+++ b/mars/dataframe/base/apply.py
@@ -564,6 +564,7 @@ def df_apply(
     output_type=None,
     index=None,
     elementwise=None,
+    skip_infer=False,
     **kwds,
 ):
     """
@@ -635,6 +636,9 @@ def df_apply(
         * ``True`` : The function is elementwise. Mars will apply
           ``func`` to original chunks. This will not introduce extra
           concatenation step and reduce overhead.
+
+    skip_infer: bool, default False
+        Whether infer dtypes when dtypes or output_type is not specified.
 
     args : tuple
         Positional arguments to pass to `func` in addition to the
@@ -741,6 +745,8 @@ def df_apply(
         output_type=output_type, output_types=output_types, object_type=object_type
     )
     output_type = output_types[0] if output_types else None
+    if skip_infer and output_type is None:
+        output_type = OutputType.df_or_series
 
     # calling member function
     if isinstance(func, str):
@@ -773,6 +779,7 @@ def series_apply(
     dtype=None,
     name=None,
     index=None,
+    skip_infer=False,
     **kwds,
 ):
     """
@@ -807,6 +814,9 @@ def series_apply(
 
     args : tuple
         Positional arguments passed to func after the series value.
+
+    skip_infer: bool, default False
+        Whether infer dtypes when dtypes or output_type is not specified.
 
     **kwds
         Additional keyword arguments passed to func.
@@ -911,6 +921,9 @@ def series_apply(
                 f"'{func_str!r}' is not a valid function "
                 f"for '{type(series).__name__}' object"
             )
+
+    if skip_infer and output_type is None:
+        output_type = OutputType.df_or_series
 
     output_types = kwds.pop("output_types", None)
     object_type = kwds.pop("object_type", None)

--- a/mars/dataframe/base/cartesian_chunk.py
+++ b/mars/dataframe/base/cartesian_chunk.py
@@ -104,6 +104,9 @@ class DataFrameCartesianChunk(DataFrameOperand, DataFrameOperandMixin):
         test_right = self._build_test_obj(right)
         output_type = self._output_types[0] if self._output_types else None
 
+        if output_type == OutputType.df_or_series:
+            return self.new_df_or_series([left, right])
+
         # try run to infer meta
         try:
             with np.errstate(all="ignore"), quiet_stdio():
@@ -158,6 +161,7 @@ class DataFrameCartesianChunk(DataFrameOperand, DataFrameOperandMixin):
         left = op.left
         right = op.right
         out = op.outputs[0]
+        out_type = op.output_types[0]
 
         if left.ndim == 2 and left.chunk_shape[1] > 1:
             if has_unknown_shape(left):
@@ -171,13 +175,25 @@ class DataFrameCartesianChunk(DataFrameOperand, DataFrameOperandMixin):
             right = yield from recursive_tile(right.rechunk({1: right.shape[1]}))
 
         out_chunks = []
-        nsplits = [[]] if out.ndim == 1 else [[], [out.shape[1]]]
+        if out_type == OutputType.dataframe:
+            nsplits = [[], [out.shape[1]]]
+        elif out_type == OutputType.series:
+            nsplits = [[]]
+        else:
+            # DataFrameOrSeries
+            nsplits = None
         i = 0
         for left_chunk in left.chunks:
             for right_chunk in right.chunks:
                 chunk_op = op.copy().reset_key()
                 chunk_op.tileable_op_key = op.key
-                if op.output_types[0] == OutputType.dataframe:
+                if out_type == OutputType.df_or_series:
+                    out_chunks.append(
+                        chunk_op.new_chunk(
+                            [left_chunk, right_chunk], index=(i, 0), collapse_axis=1
+                        )
+                    )
+                elif out_type == OutputType.dataframe:
                     shape = (np.nan, out.shape[1])
                     index_value = parse_index(
                         out.index_value.to_pandas(),
@@ -220,7 +236,7 @@ class DataFrameCartesianChunk(DataFrameOperand, DataFrameOperandMixin):
                 i += 1
 
         params = out.params
-        params["nsplits"] = tuple(tuple(ns) for ns in nsplits)
+        params["nsplits"] = tuple(tuple(ns) for ns in nsplits) if nsplits else nsplits
         params["chunks"] = out_chunks
         new_op = op.copy()
         return new_op.new_tileables(op.inputs, kws=[params])

--- a/mars/dataframe/base/cartesian_chunk.py
+++ b/mars/dataframe/base/cartesian_chunk.py
@@ -249,7 +249,7 @@ class DataFrameCartesianChunk(DataFrameOperand, DataFrameOperandMixin):
         ctx[op.outputs[0].key] = op.func(left, right, *op.args, **(op.kwargs or dict()))
 
 
-def cartesian_chunk(left, right, func, args=(), **kwargs):
+def cartesian_chunk(left, right, func, skip_infer=False, args=(), **kwargs):
     output_type = kwargs.pop("output_type", None)
     output_types = kwargs.pop("output_types", None)
     object_type = kwargs.pop("object_type", None)
@@ -259,6 +259,8 @@ def cartesian_chunk(left, right, func, args=(), **kwargs):
     output_type = output_types[0] if output_types else None
     if output_type:
         output_types = [output_type]
+    elif skip_infer:
+        output_types = [OutputType.df_or_series]
     index = kwargs.pop("index", None)
     dtypes = kwargs.pop("dtypes", None)
     memory_scale = kwargs.pop("memory_scale", None)

--- a/mars/dataframe/base/map_chunk.py
+++ b/mars/dataframe/base/map_chunk.py
@@ -188,7 +188,9 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
         )
         shape = self._kwargs.pop("shape", None)
 
-        if dtypes is not None:
+        if output_type == OutputType.df_or_series:
+            return self.new_df_or_series([df_or_series])
+        elif dtypes is not None:
             index = index if index is not None else pd.RangeIndex(-1)
             index_value = parse_index(
                 index, df_or_series, self._func, self._args, self._kwargs
@@ -253,6 +255,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
         clean_up_func(op)
         inp = op.input
         out = op.outputs[0]
+        out_type = op.output_types[0]
 
         if inp.ndim == 2 and inp.chunk_shape[1] > 1:
             if has_unknown_shape(inp):
@@ -265,12 +268,30 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
             arg_input_chunks.append(other_inp.chunks[0])
 
         out_chunks = []
-        nsplits = [[]] if out.ndim == 1 else [[], [out.shape[1]]]
-        pd_out_index = out.index_value.to_pandas()
+        if out_type == OutputType.dataframe:
+            nsplits = [[], [out.shape[1]]]
+            pd_out_index = out.index_value.to_pandas()
+        elif out_type == OutputType.series:
+            nsplits = [[]]
+            pd_out_index = out.index_value.to_pandas()
+        else:
+            # DataFrameOrSeries
+            nsplits = None
+            pd_out_index = None
         for chunk in inp.chunks:
             chunk_op = op.copy().reset_key()
             chunk_op.tileable_op_key = op.key
-            if op.output_types[0] == OutputType.dataframe:
+            if out_type == OutputType.df_or_series:
+                if inp.ndim == 2:
+                    collapse_axis = 1
+                else:
+                    collapse_axis = None
+                out_chunks.append(
+                    chunk_op.new_chunk(
+                        [chunk], index=chunk.index, collapse_axis=collapse_axis
+                    )
+                )
+            elif out_type == OutputType.dataframe:
                 if np.isnan(out.shape[0]):
                     shape = (np.nan, out.shape[1])
                 else:
@@ -304,7 +325,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
                 nsplits[0].append(out_chunk.shape[0])
 
         params = out.params
-        params["nsplits"] = tuple(tuple(ns) for ns in nsplits)
+        params["nsplits"] = tuple(tuple(ns) for ns in nsplits) if nsplits else nsplits
         params["chunks"] = out_chunks
         new_op = op.copy()
         return new_op.new_tileables(op.inputs, kws=[params])

--- a/mars/dataframe/base/map_chunk.py
+++ b/mars/dataframe/base/map_chunk.py
@@ -357,7 +357,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
         ctx[out.key] = op.func(inp, *args, **kwargs)
 
 
-def map_chunk(df_or_series, func, args=(), **kwargs):
+def map_chunk(df_or_series, func, skip_infer=False, args=(), **kwargs):
     """
     Apply function to each chunk.
 
@@ -365,6 +365,8 @@ def map_chunk(df_or_series, func, args=(), **kwargs):
     ----------
     func : function
         Function to apply to each chunk.
+    skip_infer: bool, default False
+        Whether infer dtypes when dtypes or output_type is not specified.
     args : tuple
         Positional arguments to pass to func in addition to the array/series.
     **kwargs
@@ -421,6 +423,8 @@ def map_chunk(df_or_series, func, args=(), **kwargs):
     output_type = output_types[0] if output_types else None
     if output_type:
         output_types = [output_type]
+    elif skip_infer:
+        output_types = [OutputType.df_or_series]
     index = kwargs.pop("index", None)
     dtypes = kwargs.pop("dtypes", None)
     with_chunk_index = kwargs.pop("with_chunk_index", False)

--- a/mars/dataframe/base/tests/test_apply_execution.py
+++ b/mars/dataframe/base/tests/test_apply_execution.py
@@ -17,7 +17,7 @@ import pandas as pd
 import pytest
 
 from .... import dataframe as md
-from ....dataframe.core import DataFrame
+from ....dataframe.core import DataFrame, DATAFRAME_OR_SERIES_TYPE
 from ....dataframe.fetch.core import DataFrameFetch
 
 
@@ -148,6 +148,33 @@ def test_dataframe_apply_execution(setup):
     ).execute()
     expected = df.apply(apply_func, axis=1, result_type="broadcast")
     pd.testing.assert_frame_equal(res.fetch(), expected)
+
+
+def test_apply_with_skip_infer(setup):
+    df = pd.DataFrame({"col1": [1, 2, 3, 4], "col2": list("abcd")})
+    mdf = md.DataFrame(df, chunk_size=2)
+
+    def apply_func(series):
+        if series[1] not in "abcd":
+            # make it fail when inferring
+            raise TypeError
+        else:
+            return 1
+
+    with pytest.raises(TypeError):
+        mdf.apply(apply_func, axis=1)
+
+    res = mdf.apply(apply_func, axis=1, skip_infer=True).execute()
+    assert isinstance(res, DATAFRAME_OR_SERIES_TYPE)
+    pd.testing.assert_series_equal(res.fetch(), pd.Series([1] * 4))
+
+    s = pd.Series([1, 2, 3, 4])
+    ms = md.Series(s, chunk_size=2)
+
+    apply_func = lambda x: pd.Series([1, 2])
+    res = ms.apply(apply_func, skip_infer=True).execute()
+    assert isinstance(res, DATAFRAME_OR_SERIES_TYPE)
+    pd.testing.assert_frame_equal(res.fetch(), pd.DataFrame([[1, 2]] * 4))
 
 
 def test_series_apply_execution(setup):

--- a/mars/dataframe/base/tests/test_apply_execution.py
+++ b/mars/dataframe/base/tests/test_apply_execution.py
@@ -27,7 +27,7 @@ def test_dataframe_apply_execution(setup):
 
     apply_func = lambda x: 20 if x[0] else 10
     with pytest.raises(TypeError):
-        res = mdf.apply(apply_func)
+        mdf.apply(apply_func)
 
     res = mdf.apply(apply_func, output_type="df_or_series", axis=1).execute()
     assert res.data_type == "series"

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -33,6 +33,7 @@ from ....tensor.random import rand
 from ....tests.core import require_cudf
 from ....utils import lazy_import, pd_release_version, no_default
 from ... import eval as mars_eval, cut, qcut, get_dummies
+from ...core import DATAFRAME_OR_SERIES_TYPE
 from ...datasource.dataframe import from_pandas as from_pandas_df
 from ...datasource.series import from_pandas as from_pandas_series
 from ...datasource.index import from_pandas as from_pandas_index
@@ -1967,6 +1968,47 @@ def test_map_chunk_execution(setup):
     pd.testing.assert_frame_equal(result, expected)
 
 
+def test_map_chunk_with_df_or_series_output(setup):
+    raw = pd.DataFrame(np.random.rand(10, 5), columns=[f"col{i}" for i in range(5)])
+
+    df = from_pandas_df(raw, chunk_size=(5, 3))
+
+    def f1(pdf):
+        return pdf.iloc[2, :2]
+
+    with pytest.raises(TypeError):
+        df.map_chunk(f1)
+
+    res = df.map_chunk(f1, output_type="df_or_series")
+    assert isinstance(res, DATAFRAME_OR_SERIES_TYPE)
+    res = res.execute()
+    assert res.data_type == "series"
+    assert res.dtype == np.float
+    assert not ("dtypes" in res.data_params)
+    assert res.shape == (4,)
+    pd.testing.assert_series_equal(
+        res.fetch(), pd.concat([raw.iloc[2, :2], raw.iloc[7, :2]])
+    )
+
+    def f2(pdf):
+        return pdf.iloc[[0, 2], :2]
+
+    with pytest.raises(TypeError):
+        df.map_chunk(f2)
+
+    res = df.map_chunk(f2, output_type="df_or_series")
+    assert isinstance(res, DATAFRAME_OR_SERIES_TYPE)
+    res = res.execute()
+    assert res.data_type == "dataframe"
+    pd.testing.assert_series_equal(res.dtypes, raw.dtypes[:2])
+    assert not ("dtype" in res.data_params)
+    assert res.shape == (4, 2)
+    pd.testing.assert_frame_equal(
+        res.fetch(),
+        raw.iloc[[0, 2, 5, 7], :2],
+    )
+
+
 def test_map_chunk_closure_execute(setup):
     raw = pd.DataFrame(
         np.random.randint(10**3, size=(10, 5)), columns=[f"col{i}" for i in range(5)]
@@ -2100,6 +2142,50 @@ def test_cartesian_chunk_execution(setup):
     pd.testing.assert_series_equal(
         result.sort_values().reset_index(drop=True),
         expected.sort_values().reset_index(drop=True),
+    )
+
+
+def test_cartesian_chunk_with_df_or_series(setup):
+    rs = np.random.RandomState(0)
+    raw1 = pd.DataFrame({"a": range(10), "b": rs.rand(10)})
+    raw2 = pd.DataFrame(
+        {"c": rs.randint(3, size=10), "d": rs.rand(10), "e": rs.rand(10)}
+    )
+    df1 = from_pandas_df(raw1, chunk_size=(5, 1))
+    df2 = from_pandas_df(raw2, chunk_size=(5, 1))
+
+    def f1(c1, c2):
+        return c1.iloc[[2, 4], :]
+
+    with pytest.raises(TypeError):
+        df1.cartesian_chunk(df2, f1)
+
+    res = df1.cartesian_chunk(df2, f1, output_type="df_or_series")
+
+    assert isinstance(res, DATAFRAME_OR_SERIES_TYPE)
+    res = res.execute()
+    assert res.data_type == "dataframe"
+    assert not ("dtype" in res.data_params)
+    assert res.shape == (8, 2)
+    pd.testing.assert_series_equal(res.dtypes, raw1.dtypes)
+    pd.testing.assert_frame_equal(res.fetch(), raw1.iloc[[2, 4] * 2 + [7, 9] * 2, :])
+
+    def f2(c1, c2):
+        return c1.iloc[2, :]
+
+    with pytest.raises(TypeError):
+        df1.cartesian_chunk(df2, f2)
+
+    res = df1.cartesian_chunk(df2, f2, output_type="df_or_series")
+
+    assert isinstance(res, DATAFRAME_OR_SERIES_TYPE)
+    res = res.execute()
+    assert res.data_type == "series"
+    assert not ("dtypes" in res.data_params)
+    assert res.shape == (8,)
+    pd.testing.assert_series_equal(
+        res.fetch(),
+        pd.concat([raw1.iloc[2, :], raw1.iloc[2, :], raw1.iloc[7, :], raw1.iloc[7, :]]),
     )
 
 

--- a/mars/dataframe/base/transform.py
+++ b/mars/dataframe/base/transform.py
@@ -107,7 +107,8 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
             result = in_data.transform(op.func, axis=op.axis, *op.args, **op.kwds)
 
         if isinstance(out_chunk, DATAFRAME_CHUNK_TYPE):
-            result.columns = out_chunk.dtypes.index
+            if out_chunk.dtypes is not None:
+                result.columns = out_chunk.dtypes.index
         ctx[op.outputs[0].key] = result
 
     @classmethod
@@ -141,7 +142,14 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
             params = c.params.copy()
 
             if out_df.ndim == 2:
-                if isinstance(c, DATAFRAME_CHUNK_TYPE):
+                if out_df.dtypes is None:
+                    new_dtypes = None
+                    new_shape = [c.shape[0], np.nan]
+                    new_index = c.index
+                    new_columns_value = None
+                    if c.index[0] == 0:
+                        col_sizes.append(np.nan)
+                elif isinstance(c, DATAFRAME_CHUNK_TYPE):
                     columns = c.columns_value.to_pandas()
                     new_dtypes = filter_dtypes_by_index(out_df.dtypes, columns)
 
@@ -272,32 +280,40 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
 
         return new_dtypes
 
-    def __call__(self, df, dtypes=None, index=None):
+    def __call__(self, df, dtypes=None, index=None, skip_infer=None):
         axis = getattr(self, "axis", None) or 0
         self._axis = validate_axis(axis, df)
 
-        dtypes = self._infer_df_func_returns(df, dtypes)
+        if not skip_infer:
+            dtypes = self._infer_df_func_returns(df, dtypes)
 
         if self.output_types[0] == OutputType.dataframe:
             new_shape = list(df.shape)
             new_index_value = df.index_value
             if len(new_shape) == 1:
-                new_shape.append(len(dtypes))
+                new_shape.append(len(dtypes) if dtypes is not None else np.nan)
             else:
-                new_shape[1] = len(dtypes)
+                new_shape[1] = len(dtypes) if dtypes is not None else np.nan
 
             if self.call_agg:
                 new_shape[self.axis] = np.nan
                 new_index_value = parse_index(None, (df.key, df.index_value.key))
+            if dtypes is None:
+                columns_value = None
+            else:
+                columns_value = parse_index(dtypes.index, store_data=True)
             return self.new_dataframe(
                 [df],
                 shape=tuple(new_shape),
                 dtypes=dtypes,
                 index_value=new_index_value,
-                columns_value=parse_index(dtypes.index, store_data=True),
+                columns_value=columns_value,
             )
         else:
-            name, dtype = dtypes
+            if dtypes is not None:
+                name, dtype = dtypes
+            else:
+                name, dtype = None, None
 
             if isinstance(df, DATAFRAME_TYPE):
                 new_shape = (df.shape[1 - axis],)
@@ -315,7 +331,7 @@ class TransformOperand(DataFrameOperand, DataFrameOperandMixin):
             )
 
 
-def df_transform(df, func, axis=0, *args, dtypes=None, **kwargs):
+def df_transform(df, func, axis=0, *args, dtypes=None, skip_infer=False, **kwargs):
     """
     Call ``func`` on self producing a DataFrame with transformed values.
 
@@ -339,6 +355,9 @@ def df_transform(df, func, axis=0, *args, dtypes=None, **kwargs):
 
     dtypes : Series, default None
         Specify dtypes of returned DataFrames. See `Notes` for more details.
+
+    skip_infer: bool, default False
+        Whether infer dtypes when dtypes or output_type is not specified.
 
     *args
         Positional arguments to pass to `func`.
@@ -405,11 +424,18 @@ def df_transform(df, func, axis=0, *args, dtypes=None, **kwargs):
         output_types=[OutputType.dataframe],
         call_agg=kwargs.pop("_call_agg", False),
     )
-    return op(df, dtypes=dtypes)
+    return op(df, dtypes=dtypes, skip_infer=skip_infer)
 
 
 def series_transform(
-    series, func, convert_dtype=True, axis=0, *args, dtype=None, **kwargs
+    series,
+    func,
+    convert_dtype=True,
+    axis=0,
+    *args,
+    skip_infer=False,
+    dtype=None,
+    **kwargs
 ):
     """
     Call ``func`` on self producing a Series with transformed values.
@@ -433,6 +459,9 @@ def series_transform(
 
     dtype : numpy.dtype, default None
         Specify dtypes of returned DataFrames. See `Notes` for more details.
+
+    skip_infer: bool, default False
+        Whether infer dtypes when dtypes or output_type is not specified.
 
     *args
         Positional arguments to pass to `func`.
@@ -501,4 +530,4 @@ def series_transform(
         call_agg=kwargs.pop("_call_agg", False),
     )
     dtypes = (series.name, dtype) if dtype is not None else None
-    return op(series, dtypes=dtypes)
+    return op(series, dtypes=dtypes, skip_infer=skip_infer)

--- a/mars/dataframe/groupby/apply.py
+++ b/mars/dataframe/groupby/apply.py
@@ -272,6 +272,7 @@ def groupby_apply(
     dtype=None,
     name=None,
     index=None,
+    skip_infer=None,
     **kwargs,
 ):
     """
@@ -311,6 +312,9 @@ def groupby_apply(
     index : Index, default None
         Specify index of returned object. See `Notes` for more details.
 
+    skip_infer: bool, default False
+        Whether infer dtypes when dtypes or output_type is not specified.
+
     args, kwargs : tuple and dict
         Optional positional and keyword arguments to pass to `func`.
 
@@ -345,6 +349,8 @@ def groupby_apply(
     output_types = validate_output_types(
         output_types=output_types, output_type=output_type, object_type=object_type
     )
+    if output_types is None and skip_infer:
+        output_types = [OutputType.df_or_series]
 
     dtypes = make_dtypes(dtypes)
     dtype = make_dtype(dtype)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
We have add a new type `DataFrameOrSeries` in #56 and support this type in `df.apply`, in this PR, other operands also support passing `df_or_dataframe` type when we can't determine the output types before executing. Also, `skip_infer` is added to allow user skip inferring for those udfs.

Here are user defined functions:
- DataFrame.apply
- DataFrame.map
- DataFrame.transform
- DataFrame.map_chunk
- DataFrame.cartesian_chunk
- GroupBy.apply
- GroupBy.transform

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
