### PR TITLE
Fix: no disk info on web

### DIFF
--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -606,8 +606,11 @@ class StorageManagerActor(mo.StatelessActor):
         from ..cluster import DiskInfo
 
         disk_infos = []
-        if self._cluster_api is not None and "filesystem" in self._init_params["numa-0"]:
-            if self._init_params["numa-0"]['filesystem']['level'] == StorageLevel.DISK:
+        if (
+            self._cluster_api is not None
+            and "filesystem" in self._init_params["numa-0"]
+        ):
+            if self._init_params["numa-0"]["filesystem"]["level"] == StorageLevel.DISK:
                 params = self._init_params["numa-0"]["filesystem"]
                 size = params["size"]
                 for path in params["root_dirs"]:

--- a/mars/services/storage/core.py
+++ b/mars/services/storage/core.py
@@ -606,9 +606,10 @@ class StorageManagerActor(mo.StatelessActor):
         from ..cluster import DiskInfo
 
         disk_infos = []
-        if self._cluster_api is not None and "disk" in self._init_params["numa-0"]:
-            params = self._init_params["numa-0"]["disk"]
-            size = params["size"]
-            for path in params["root_dirs"]:
-                disk_infos.append(DiskInfo(path=path, limit_size=size))
-            await self._cluster_api.set_node_disk_info(disk_infos)
+        if self._cluster_api is not None and "filesystem" in self._init_params["numa-0"]:
+            if self._init_params["numa-0"]['filesystem']['level'] == StorageLevel.DISK:
+                params = self._init_params["numa-0"]["filesystem"]
+                size = params["size"]
+                for path in params["root_dirs"]:
+                    disk_infos.append(DiskInfo(path=path, limit_size=size))
+                await self._cluster_api.set_node_disk_info(disk_infos)

--- a/mars/services/storage/tests/test_spill.py
+++ b/mars/services/storage/tests/test_spill.py
@@ -21,6 +21,8 @@ import numpy as np
 import pytest
 
 from ...cluster import MockClusterAPI
+from ...cluster.supervisor.node_info import NodeInfoCollectorActor
+from ...cluster.uploader import NodeInfoUploaderActor
 from .... import oscar as mo
 from ....storage import StorageLevel, PlasmaStorage
 from ....utils import calc_data_size
@@ -76,6 +78,7 @@ def _build_storage_config():
 
 @pytest.fixture
 async def create_actors(actor_pool):
+    _ = await MockClusterAPI.create(address=actor_pool.external_address)
     storage_configs = _build_storage_config()
     manager_ref = await mo.create_actor(
         StorageManagerActor,
@@ -140,7 +143,13 @@ async def test_spill(create_actors):
 @pytest.mark.asyncio
 async def test_disk_info(create_actors):
     worker_address, _, _ = create_actors
-    _ = await MockClusterAPI.create(address=worker_address)
+    uploader_ref = await mo.actor_ref(
+        address=worker_address, uid=NodeInfoUploaderActor.default_uid()
+    )
+    await uploader_ref.upload_node_info()
+    collector_ref = await mo.actor_ref(
+        address=worker_address, uid=NodeInfoCollectorActor.default_uid()
+    )
     storage_manager = await mo.actor_ref(
         uid=StorageManagerActor.default_uid(), address=worker_address
     )
@@ -148,6 +157,12 @@ async def test_disk_info(create_actors):
     assert "filesystem" in init_params
     assert "level" in init_params["filesystem"]
     assert init_params["filesystem"]["level"] == StorageLevel.DISK
+
+    node_info = await collector_ref.get_nodes_info(detail=True)
+    disk_partitions = node_info[worker_address]["detail"]["disk"]["partitions"]
+    assert disk_partitions
+    for _, info in disk_partitions.items():
+        assert "inode_used" in info
 
 
 class DelayPutStorageHandler(StorageHandlerActor):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->
Fix no disk info on web if user uses filesystem in yml config.
For example:
```yaml
"@inherits": base_config.yml
storage:
  backends: [shared_memory, filesystem]
  filesystem:
    level: disk
    root_dirs: /var/folders/k5/bxy40w394cz_z73k7f69bc2h0000gn/T/
```

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
