### PR TITLE
Fix: ensure dataframe.all acts identical to pandas

### DIFF
--- a/mars/dataframe/reduction/all.py
+++ b/mars/dataframe/reduction/all.py
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import pandas as pd
+
 from ... import opcodes as OperandDef
 from ...config import options
 from ...core import OutputType
-from .core import DataFrameReductionOperand, DataFrameReductionMixin
+from .core import (
+    DataFrameReductionOperand,
+    DataFrameReductionMixin,
+    recursive_tile,
+    DATAFRAME_TYPE,
+)
 
 
 class DataFrameAll(DataFrameReductionOperand, DataFrameReductionMixin):
@@ -26,10 +34,51 @@ class DataFrameAll(DataFrameReductionOperand, DataFrameReductionMixin):
     def is_atomic(self):
         return True
 
+    @classmethod
+    def tile(cls, op):
+        in_df = op.inputs[0]
+        out_df = op.outputs[0]
+        if op.axis is None and isinstance(in_df, DATAFRAME_TYPE):
+            dtypes = pd.Series([out_df.dtype])
+            index = in_df.dtypes.index
+            out_df = yield from recursive_tile(
+                in_df.agg(
+                    cls.get_reduction_callable(op),
+                    axis=0,
+                    _numeric_only=op.numeric_only,
+                    _bool_only=op.bool_only,
+                    _combine_size=op.combine_size,
+                    _output_type=OutputType.series,
+                    _dtypes=dtypes,
+                    _index=index,
+                )
+            )
+            out_df = yield from recursive_tile(
+                out_df.agg(
+                    cls.get_reduction_callable(op),
+                    axis=0,
+                    _numeric_only=op.numeric_only,
+                    _bool_only=op.bool_only,
+                    _combine_size=op.combine_size,
+                    _output_type=OutputType.scalar,
+                    _dtypes=out_df.dtype,
+                    _index=None,
+                )
+            )
+            return [out_df]
+        else:
+            return (yield from super().tile(op))
+
+    def __call__(self, df):
+        if self.axis is None and isinstance(df, DATAFRAME_TYPE):
+            return self.new_scalar([df], np.bool)
+        else:
+            return super().__call__(df)
+
 
 def all_series(
     series,
-    axis=None,
+    axis=0,
     bool_only=None,
     skipna=True,
     level=None,
@@ -52,7 +101,7 @@ def all_series(
 
 def all_dataframe(
     df,
-    axis=None,
+    axis=0,
     bool_only=None,
     skipna=True,
     level=None,
@@ -60,13 +109,14 @@ def all_dataframe(
     method=None,
 ):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    output_types = [OutputType.series] if axis is not None else [OutputType.scalar]
     op = DataFrameAll(
         axis=axis,
         skipna=skipna,
         level=level,
         bool_only=bool_only,
         combine_size=combine_size,
-        output_types=[OutputType.series],
+        output_types=output_types,
         use_inf_as_na=use_inf_as_na,
         method=method,
     )

--- a/mars/dataframe/reduction/any.py
+++ b/mars/dataframe/reduction/any.py
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import pandas as pd
+
 from ... import opcodes as OperandDef
 from ...config import options
 from ...core import OutputType
-from .core import DataFrameReductionOperand, DataFrameReductionMixin
+from .core import (
+    DataFrameReductionOperand,
+    DataFrameReductionMixin,
+    recursive_tile,
+    DATAFRAME_TYPE,
+)
 
 
 class DataFrameAny(DataFrameReductionOperand, DataFrameReductionMixin):
@@ -26,10 +34,51 @@ class DataFrameAny(DataFrameReductionOperand, DataFrameReductionMixin):
     def is_atomic(self):
         return True
 
+    @classmethod
+    def tile(cls, op):
+        in_df = op.inputs[0]
+        out_df = op.outputs[0]
+        if op.axis is None and isinstance(in_df, DATAFRAME_TYPE):
+            dtypes = pd.Series([out_df.dtype])
+            index = in_df.dtypes.index
+            out_df = yield from recursive_tile(
+                in_df.agg(
+                    cls.get_reduction_callable(op),
+                    axis=0,
+                    _numeric_only=op.numeric_only,
+                    _bool_only=op.bool_only,
+                    _combine_size=op.combine_size,
+                    _output_type=OutputType.series,
+                    _dtypes=dtypes,
+                    _index=index,
+                )
+            )
+            out_df = yield from recursive_tile(
+                out_df.agg(
+                    cls.get_reduction_callable(op),
+                    axis=0,
+                    _numeric_only=op.numeric_only,
+                    _bool_only=op.bool_only,
+                    _combine_size=op.combine_size,
+                    _output_type=OutputType.scalar,
+                    _dtypes=out_df.dtype,
+                    _index=None,
+                )
+            )
+            return [out_df]
+        else:
+            return (yield from super().tile(op))
+
+    def __call__(self, df):
+        if self.axis is None and isinstance(df, DATAFRAME_TYPE):
+            return self.new_scalar([df], np.bool)
+        else:
+            return super().__call__(df)
+
 
 def any_series(
     series,
-    axis=None,
+    axis=0,
     bool_only=None,
     skipna=True,
     level=None,
@@ -52,7 +101,7 @@ def any_series(
 
 def any_dataframe(
     df,
-    axis=None,
+    axis=0,
     bool_only=None,
     skipna=True,
     level=None,
@@ -60,13 +109,14 @@ def any_dataframe(
     method=None,
 ):
     use_inf_as_na = options.dataframe.mode.use_inf_as_na
+    output_types = [OutputType.series] if axis is not None else [OutputType.scalar]
     op = DataFrameAny(
         axis=axis,
         skipna=skipna,
         level=level,
         bool_only=bool_only,
         combine_size=combine_size,
-        output_types=[OutputType.series],
+        output_types=output_types,
         use_inf_as_na=use_inf_as_na,
         method=method,
     )

--- a/mars/dataframe/reduction/tests/test_reduction_execution.py
+++ b/mars/dataframe/reduction/tests/test_reduction_execution.py
@@ -250,6 +250,10 @@ def test_dataframe_reduction(
     pd.testing.assert_series_equal(
         compute(data, axis="index", numeric_only=True), r.execute().fetch()
     )
+    r = compute(md.DataFrame(data), axis="index", numeric_only=True)
+    pd.testing.assert_series_equal(
+        compute(data, axis="index", numeric_only=True), r.execute().fetch()
+    )
 
     data1 = pd.DataFrame(rs.rand(10, 10), columns=[str(i) for i in range(10)])
     data2 = pd.DataFrame(rs.rand(10, 10), columns=[str(i) for i in range(10)])
@@ -468,6 +472,9 @@ def test_dataframe_bool_reduction(setup, check_ref_counts, func_name):
 
     r = compute(md.DataFrame(data, chunk_size=3), axis=1)
     pd.testing.assert_series_equal(compute(data, axis=1), r.execute().fetch())
+
+    r = compute(md.DataFrame(data, chunk_size=3), axis=None)
+    assert compute(data, axis=None) == r.execute().fetch()
 
     # test null
     np_data = rs.rand(20, 10)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #75 and Fix bool_only and numeric_only of reduction function when has single chunk
## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
