### PR TITLE
fix: Fix wrong results of `DataFrame.replace`

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -112,7 +112,6 @@ jobs:
               # Pandas 1.4 compatibility issue, maybe pandas 1.4 bugs
               # https://github.com/mars-project/mars/issues/3251
               # https://github.com/mars-project/mars/issues/3252
-              pip install "pandas<1.4"
             fi
             if [ -n "$RUN_DASK" ]; then
               pip install dask[complete] mimesis sklearn

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -112,6 +112,7 @@ jobs:
               # Pandas 1.4 compatibility issue, maybe pandas 1.4 bugs
               # https://github.com/mars-project/mars/issues/3251
               # https://github.com/mars-project/mars/issues/3252
+              pip install "pandas<1.4"
             fi
             if [ -n "$RUN_DASK" ]; then
               pip install dask[complete] mimesis sklearn

--- a/mars/dataframe/missing/replace.py
+++ b/mars/dataframe/missing/replace.py
@@ -189,9 +189,9 @@ class DataFrameReplace(DataFrameOperand, DataFrameOperandMixin):
             tileable_inputs_ex.append(value)
 
         # fill methods only available when `to_replace` is a scalar, list or tuple
-        # and `value` is None.
+        # and `value` is no_default.
         with_fill = (
-            op.value is None
+            op.value is no_default
             and not isinstance(op.to_replace, dict)
             and op.method is not None
         )
@@ -582,7 +582,7 @@ def _replace(
     regex=False,
     method=no_default,
 ):
-    if not isinstance(to_replace, dict) and value is None and limit is not None:
+    if not isinstance(to_replace, dict) and value is no_default and limit is not None:
         raise NotImplementedError("fill with limit not supported when value is None")
 
     if not isinstance(regex, bool):
@@ -601,7 +601,7 @@ def _replace(
 def df_replace(
     df,
     to_replace=no_default,
-    value=None,
+    value=no_default,
     inplace=False,
     limit=None,
     regex=False,
@@ -621,7 +621,7 @@ def df_replace(
 def series_replace(
     series,
     to_replace=no_default,
-    value=None,
+    value=no_default,
     inplace=False,
     limit=None,
     regex=False,

--- a/mars/dataframe/missing/tests/test_missing_execution.py
+++ b/mars/dataframe/missing/tests/test_missing_execution.py
@@ -262,8 +262,9 @@ def test_replace_execution(setup):
     r = df.replace(-1, 999)
     pd.testing.assert_frame_equal(r.execute().fetch(), df_raw.replace(-1, 999))
 
-    r = df.replace({-1: 999})
-    pd.testing.assert_frame_equal(r.execute().fetch(), df_raw.replace({-1: 999}))
+    if pd.__version__ >= "1.4.4":
+        r = df.replace({-1: 999})
+        pd.testing.assert_frame_equal(r.execute().fetch(), df_raw.replace({-1: 999}))
 
     raw_to_replace = pd.Series([-1, 1, 2])
     to_replace_series = md.Series(raw_to_replace)
@@ -279,8 +280,11 @@ def test_replace_execution(setup):
         df.execute().fetch(), df_raw.replace({"A": -1}, {"A": 9})
     )
 
-    df.replace({"A": {-1: 9}}, inplace=True)
-    pd.testing.assert_frame_equal(df.execute().fetch(), df_raw.replace({"A": {-1: 9}}))
+    if pd.__version__ >= "1.4.4":
+        df.replace({"A": {-1: 9}}, inplace=True)
+        pd.testing.assert_frame_equal(
+            df.execute().fetch(), df_raw.replace({"A": {-1: 9}})
+        )
 
     # series cases
     series_raw = pd.Series(-1, index=range(20))
@@ -288,8 +292,9 @@ def test_replace_execution(setup):
         series_raw.iloc[random.randint(0, 19)] = random.randint(0, 99)
     series = md.Series(series_raw, chunk_size=4)
 
-    r = series.replace(-1)
-    pd.testing.assert_series_equal(r.execute().fetch(), series_raw.replace(-1))
+    if pd.__version__ >= "1.4.4":
+        r = series.replace(-1)
+        pd.testing.assert_series_equal(r.execute().fetch(), series_raw.replace(-1))
 
     r = series.replace(-1, method="ffill")
     pd.testing.assert_series_equal(

--- a/mars/dataframe/missing/tests/test_missing_execution.py
+++ b/mars/dataframe/missing/tests/test_missing_execution.py
@@ -262,6 +262,9 @@ def test_replace_execution(setup):
     r = df.replace(-1, 999)
     pd.testing.assert_frame_equal(r.execute().fetch(), df_raw.replace(-1, 999))
 
+    r = df.replace({-1: 999})
+    pd.testing.assert_frame_equal(r.execute().fetch(), df_raw.replace({-1: 999}))
+
     raw_to_replace = pd.Series([-1, 1, 2])
     to_replace_series = md.Series(raw_to_replace)
     raw_value = pd.Series([2, 3, -1])
@@ -276,11 +279,17 @@ def test_replace_execution(setup):
         df.execute().fetch(), df_raw.replace({"A": -1}, {"A": 9})
     )
 
+    df.replace({"A": {-1: 9}}, inplace=True)
+    pd.testing.assert_frame_equal(df.execute().fetch(), df_raw.replace({"A": {-1: 9}}))
+
     # series cases
     series_raw = pd.Series(-1, index=range(20))
     for _ in range(10):
         series_raw.iloc[random.randint(0, 19)] = random.randint(0, 99)
     series = md.Series(series_raw, chunk_size=4)
+
+    r = series.replace(-1)
+    pd.testing.assert_series_equal(r.execute().fetch(), series_raw.replace(-1))
 
     r = series.replace(-1, method="ffill")
     pd.testing.assert_series_equal(


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #85 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
