### PR TITLE
fix: Modify signature of `df.map_chunk`

### DIFF
--- a/mars/dataframe/base/map_chunk.py
+++ b/mars/dataframe/base/map_chunk.py
@@ -357,7 +357,7 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
         ctx[out.key] = op.func(inp, *args, **kwargs)
 
 
-def map_chunk(df_or_series, func, skip_infer=False, args=(), **kwargs):
+def map_chunk(df_or_series, func, args=(), kwargs=None, skip_infer=False, **kw):
     """
     Apply function to each chunk.
 
@@ -365,12 +365,12 @@ def map_chunk(df_or_series, func, skip_infer=False, args=(), **kwargs):
     ----------
     func : function
         Function to apply to each chunk.
-    skip_infer: bool, default False
-        Whether infer dtypes when dtypes or output_type is not specified.
     args : tuple
         Positional arguments to pass to func in addition to the array/series.
-    **kwargs
+    kwargs: Dict
         Additional keyword arguments to pass as keywords arguments to func.
+    skip_infer: bool, default False
+        Whether infer dtypes when dtypes or output_type is not specified.
 
     Returns
     -------
@@ -414,9 +414,9 @@ def map_chunk(df_or_series, func, skip_infer=False, args=(), **kwargs):
     1  4  2
     2  4  3
     """
-    output_type = kwargs.pop("output_type", None)
-    output_types = kwargs.pop("output_types", None)
-    object_type = kwargs.pop("object_type", None)
+    output_type = kw.pop("output_type", None)
+    output_types = kw.pop("output_types", None)
+    object_type = kw.pop("object_type", None)
     output_types = validate_output_types(
         output_type=output_type, output_types=output_types, object_type=object_type
     )
@@ -425,15 +425,17 @@ def map_chunk(df_or_series, func, skip_infer=False, args=(), **kwargs):
         output_types = [output_type]
     elif skip_infer:
         output_types = [OutputType.df_or_series]
-    index = kwargs.pop("index", None)
-    dtypes = kwargs.pop("dtypes", None)
-    with_chunk_index = kwargs.pop("with_chunk_index", False)
+    index = kw.pop("index", None)
+    dtypes = kw.pop("dtypes", None)
+    with_chunk_index = kw.pop("with_chunk_index", False)
+    if kw:  # pragma: no cover
+        raise TypeError(f"Unknown kwargs: {kw}")
 
     op = DataFrameMapChunk(
         input=df_or_series,
         func=func,
         args=args,
-        kwargs=kwargs,
+        kwargs=kwargs or {},
         output_types=output_types,
         with_chunk_index=with_chunk_index,
     )

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -1983,7 +1983,9 @@ def test_map_chunk_execution(setup):
 
     df = from_pandas_df(raw, chunk_size=5)
     df_arg = from_pandas_df(raw, chunk_size=6)
-    r = df.map_chunk(f6, mars_df=df_arg, output_type="dataframe", dtypes=df.dtypes)
+    r = df.map_chunk(
+        f6, kwargs=dict(mars_df=df_arg), output_type="dataframe", dtypes=df.dtypes
+    )
     expected = raw + raw.sum()
     result = r.execute().fetch()
     pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
`df.map_chunk` would lead to wrong result if user function has parameters like `index`, `output_type`, this PR use a `kwargs` to pass keywords arguments to func not in `**kwargs`.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
