### PR TITLE
Support df_or_series output type for remote functions

### DIFF
--- a/mars/remote/core.py
+++ b/mars/remote/core.py
@@ -138,6 +138,10 @@ class RemoteFunction(RemoteOperandMixin, Operand):
             elif out_type == OutputType.series:
                 chunk_params["index"] = (0,)
                 chunk_params["shape"] = (np.nan,)
+            elif out_type == OutputType.df_or_series:
+                chunk_params["index"] = (0, 0)
+                chunk_params["shape"] = (np.nan, np.nan)
+                chunk_params["collapse_axis"] = 1
             else:
                 chunk_params["index"] = ()
                 chunk_params["shape"] = ()


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
In #71 , we support specifying output type of remote function, however it would fail when specifying `df_or_series` type which was implemented in #56 , this PR makes it work for `df_or_series`.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
