### PR TITLE
BUG: df.apply with list input returns wrong answer when axis=1

### DIFF
--- a/mars/dataframe/base/apply.py
+++ b/mars/dataframe/base/apply.py
@@ -737,7 +737,7 @@ def df_apply(
     2  1  2
     """
     if isinstance(func, (list, dict)):
-        return df.aggregate(func)
+        return df.aggregate(func, axis)
 
     output_types = kwds.pop("output_types", None)
     object_type = kwds.pop("object_type", None)

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -339,6 +339,11 @@ def test_data_frame_apply_execute(setup):
         expected = df_raw.apply(["sum", "max"])
         pd.testing.assert_frame_equal(result, expected)
 
+        r = df.apply(["sum", "max"], axis=1)
+        result = r.execute().fetch()
+        expected = df_raw.apply(["sum", "max"], axis=1)
+        pd.testing.assert_frame_equal(result, expected)
+
         r = df.apply(np.sqrt)
         result = r.execute().fetch()
         expected = df_raw.apply(np.sqrt)


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #59

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
