### PR TITLE
Fix: map_chunk output type inference

### DIFF
--- a/mars/dataframe/base/map_chunk.py
+++ b/mars/dataframe/base/map_chunk.py
@@ -210,21 +210,12 @@ class DataFrameMapChunk(DataFrameOperand, DataFrameOperandMixin):
                 shape = attrs["shape"]
                 dtypes = attrs["dtypes"]
             except:  # noqa: E722  # nosec
-                if df_or_series.ndim == 1 or output_type == OutputType.series:
-                    output_type = OutputType.series
-                    index = index if index is not None else pd.RangeIndex(-1)
-                    index_value = parse_index(
-                        index, df_or_series, self._func, self._args, self._kwargs
-                    )
-                    dtypes = pd.Series([np.dtype(object)])
-                    shape = (np.nan,)
-                else:
-                    raise TypeError(
-                        "Cannot determine `output_type`, "
-                        "you have to specify it as `dataframe` or `series`, "
-                        "for dataframe, `dtypes` is required as well "
-                        "if output_type='dataframe'"
-                    )
+                raise TypeError(
+                    "Cannot determine `output_type`, "
+                    "you have to specify it as `dataframe` or `series`, "
+                    "for dataframe, `dtypes` is required as well "
+                    "if output_type='dataframe'"
+                )
 
         inputs = (
             [df_or_series]

--- a/mars/dataframe/base/tests/test_base_execution.py
+++ b/mars/dataframe/base/tests/test_base_execution.py
@@ -1911,7 +1911,7 @@ def test_map_chunk_execution(setup):
         r = df.map_chunk(f3)
         _ = r.execute().fetch()
 
-    r = df.map_chunk(f3, output_type="series")
+    r = df.map_chunk(f3, output_type="series", dtypes=pd.Series([np.int64]))
     result = r.execute(extra_config={"check_dtypes": False}).fetch()
     expected = f3(raw)
     pd.testing.assert_series_equal(result, expected)
@@ -1989,6 +1989,12 @@ def test_map_chunk_execution(setup):
     expected = raw + raw.sum()
     result = r.execute().fetch()
     pd.testing.assert_frame_equal(result, expected)
+
+    def f7(s):
+        return s.to_json()
+
+    with pytest.raises(TypeError):
+        series.map_chunk(f7)
 
 
 def test_map_chunk_with_df_or_series_output(setup):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [] Ensure all linting tests pass, see [here](https://docs.pymars.org/en/latest/development/contributing.html#check-code-styles) for how to run them
